### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,28 @@
 
 Creates jQuery layouts with CSS3 animation effects and call back events.
 
-See the [Freewall homepage](http://vnjs.net/www/project/freewall/) for documentation.
+## Setup
+
+If you need to add `<meta>` tags to the DOM, you will need to create an `index.html` file that contains this HTML:
+```
+<head>
+  <meta content=​"text/​html;​ charset=utf-8" http-equiv=​"content-type">​
+</head>
+
+<body>
+  <!-- This will not render a 2nd body. -->
+</body>
+```
+
+**IMPORTANT**: Do not put this inside of a Template or above `{{> yield}}` when using [iron:router](https://atmospherejs.com/iron/router). When a Template is called it will be put inside of the `<body>` like this:
+
+```
+<body>
+  <head>
+    <meta content=​"text/​html;​ charset=utf-8" http-equiv=​"content-type">​
+  </head>
+  <!-- Template -->
+</body>
+```
+
+See the [Freewall homepage](http://vnjs.net/www/project/freewall/) for documentation for more info.


### PR DESCRIPTION
It is a bit less documented in iron:router that you need to put your
<head> tag outside of all Templates so that Meteor can add it normally.
Otherwise, the <head> tag inside of a Template will be put inside of the
<body>. That is not very useful...
